### PR TITLE
Ensure GPT autofill prompts focus on active field

### DIFF
--- a/story_builder/dialogs.py
+++ b/story_builder/dialogs.py
@@ -99,6 +99,8 @@ class DialogRunner:
         instruction: str,
         context: Optional[Dict[str, object]] = None,
     ) -> str:
+        target_label = format_field_label(key)
+
         lines = [
             "You are a story writing assistant and I want to build an immersive story outline.",
         ]
@@ -115,7 +117,7 @@ class DialogRunner:
         current_value = (current_value or "").strip()
         if current_value:
             lines.append(
-                f"For the {format_field_label(key)} I currently have: {current_value}."
+                f"For the {target_label} I currently have: {current_value}."
             )
 
         instruction = (instruction or "").strip()
@@ -123,7 +125,11 @@ class DialogRunner:
             lines.append(f"In this step of the process I would like for you to {instruction}")
         else:
             lines.append(
-                f"In this step of the process I would like for you to suggest an update for the {format_field_label(key)}."
+                f"In this step of the process I would like for you to suggest an update for the {target_label}."
             )
+
+        lines.append(
+            f"Only provide content for the {target_label}; do not propose changes for any other fields."
+        )
 
         return "\n".join(lines)

--- a/tests/test_prompt_logic.py
+++ b/tests/test_prompt_logic.py
@@ -37,7 +37,7 @@ class CaptureDialog:
 
 
 def test_fieldwalker_includes_existing_context_for_autofill():
-    data = json.loads(Path("tests/sample_data/story_example.json").read_text())
+    data = json.loads(Path("tests/sample_data/example_project/Story.json").read_text())
     prompts = {
         "story_preferences": {
             "tone": "Suggest a fitting tone (serious, lighthearted, grimdark, whimsical) for the story."
@@ -51,15 +51,17 @@ def test_fieldwalker_includes_existing_context_for_autofill():
     tone_call = next(call for call in dialog.calls if call["key"] == "tone")
     assert tone_call["prompt_instruction"].startswith("Suggest a fitting tone")
     assert tone_call["context"] == {
-        "setting": "A sprawling space station on the edge of a nebula",
-        "themes": "Exploration, Political intrigue",
+        "setting": "a steam punk world",
+        "themes": "Love and mystery",
+        "magic_level": "low",
     }
 
 
 def test_build_prompt_formats_context_and_instruction():
     context = {
-        "setting": "A sprawling space station on the edge of a nebula",
-        "themes": ["Exploration", "Political intrigue"],
+        "setting": "a steam punk world",
+        "themes": ["Love and mystery"],
+        "magic_level": "low",
     }
 
     prompt = DialogRunner.build_prompt(
@@ -71,7 +73,9 @@ def test_build_prompt_formats_context_and_instruction():
 
     assert "You are a story writing assistant" in prompt
     assert "This is what I have so far:" in prompt
-    assert "- Setting: A sprawling space station on the edge of a nebula" in prompt
-    assert "- Themes: Exploration, Political intrigue" in prompt
+    assert "- Setting: a steam punk world" in prompt
+    assert "- Themes: Love and mystery" in prompt
+    assert "- Magic level: low" in prompt
     assert "Suggest a fitting tone" in prompt
     assert "For the Tone I currently have" not in prompt
+    assert "Only provide content for the Tone" in prompt


### PR DESCRIPTION
## Summary
- scope prompt construction so GPT is told to respond only for the active field and reiterates that constraint.
- collect key story context (setting, themes, magic level) from the project when autofilling so related prompts always include those cues.
- align prompt logic tests with the updated sample project structure and new prompt expectations.

## Testing
- pytest tests/test_prompt_logic.py

------
https://chatgpt.com/codex/tasks/task_e_68d90704c2dc8324af57401f11f6d541