### PR TITLE
Add response-only TextGenerator API for TextGenerator

### DIFF
--- a/story_builder/autofill.py
+++ b/story_builder/autofill.py
@@ -27,8 +27,8 @@ class AutofillService:
         if self._stub_mode():
             return "".join(random.choices(string.ascii_uppercase + string.digits, k=4))
         if tg is None:
-        # Fallback if text_generator isn't available
+            # Fallback if text_generator isn't available
             return "".join(random.choices(string.ascii_lowercase, k=12))
         gen = tg.TextGenerator(max_new_tokens=self.max_new_tokens)
-        out = gen.generate_text(prompt_text)
+        out = gen.generate_response(prompt_text)
         return (out or "").strip()


### PR DESCRIPTION
## Summary
- add a shared generation helper and a new `generate_response` API that strips the original prompt
- update the autofill service to consume the response-only output for completions
- extend the text generator tests to cover the new response behaviour

## Testing
- `pytest tests/test_text_generator.py` *(fails: could not import torch, so the module is skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68d93a041a1c8324bd3e52b383cd300b