### PR TITLE
Add storyline writing tab with turn-by-turn workflow

### DIFF
--- a/json_templates/storyline_template.json
+++ b/json_templates/storyline_template.json
@@ -1,0 +1,5 @@
+{
+  "title": "",
+  "summary": "",
+  "turns": []
+}

--- a/json_templates/storyline_template_prompt.json
+++ b/json_templates/storyline_template_prompt.json
@@ -1,0 +1,10 @@
+{
+  "default_instruction": "Write the next major beat of the storyline in 2-4 sentences. Focus on strong player hooks, escalating stakes, and vivid sensory details.",
+  "turn_instructions": [
+    "Establish the campaign hook, location, and initial conflict that draws the heroes together.",
+    "Introduce the primary antagonist or obstacle that complicates the heroes' goals.",
+    "Describe a turning point that raises the stakes and reveals hidden information.",
+    "Outline the climactic showdown or challenge and the consequences of success or failure.",
+    "Suggest an epilogue beat that teases future adventures or unresolved threads."
+  ]
+}

--- a/story_builder/project.py
+++ b/story_builder/project.py
@@ -74,6 +74,10 @@ class Project:
         return os.path.join(project_folder, "Story.json")
 
 
+    def storyline_path(self, project_folder: str) -> str:
+        return os.path.join(project_folder, "Storyline.json")
+
+
     # --- Characters ---
     def characters_dir(self, project_folder: str) -> str:
         d = os.path.join(project_folder, "Characters")

--- a/story_builder/storyline.py
+++ b/story_builder/storyline.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List
+
+from .project import Project
+from .logger import Logger
+from .utils import summarize_value_for_prompt, format_field_label
+
+
+class StorylineManager:
+    """Manage storyline persistence and prompting metadata."""
+
+    TEMPLATE_FILENAME = "storyline_template.json"
+    PROMPT_FILENAME = "storyline_template_prompt.json"
+    DEFAULT_TEMPLATE: Dict[str, Any] = {"title": "", "summary": "", "turns": []}
+    DEFAULT_INSTRUCTION = (
+        "Write the next major beat of the storyline in 2-4 sentences, highlighting"
+        " conflicts, stakes, and hooks for the players."
+    )
+
+    def __init__(self, project: Project, logger: Logger | None = None):
+        self.project = project
+        self.logger = logger
+        self.prompt_config: Dict[str, Any] = {}
+
+    # --- Template / persistence helpers ---
+    def load_prompt_config(self) -> Dict[str, Any]:
+        data = self.project.load_prompt_template(self.PROMPT_FILENAME)
+        if not isinstance(data, dict):
+            data = {}
+        self.prompt_config = data
+        return data
+
+    def ensure_initialized(self, project_folder: str) -> None:
+        path = self.project.storyline_path(project_folder)
+        if os.path.exists(path):
+            return
+        template = self.project.load_template(self.TEMPLATE_FILENAME)
+        if not isinstance(template, dict) or not template:
+            template = dict(self.DEFAULT_TEMPLATE)
+        cleared = self.project.clear_template(template)
+        if not isinstance(cleared, dict):
+            cleared = dict(self.DEFAULT_TEMPLATE)
+        cleared.setdefault("turns", [])
+        if not isinstance(cleared["turns"], list):
+            cleared["turns"] = []
+        self.project.save_json(cleared, path)
+        if self.logger:
+            self.logger.log("StorylineManager: created storyline file")
+
+    def load(self, project_folder: str) -> Dict[str, Any]:
+        self.ensure_initialized(project_folder)
+        return self.project.read_json(self.project.storyline_path(project_folder))
+
+    def save(self, project_folder: str, data: Dict[str, Any]) -> None:
+        if not isinstance(data, dict):
+            data = dict(self.DEFAULT_TEMPLATE)
+        turns = data.get("turns")
+        if not isinstance(turns, list):
+            data["turns"] = []
+        self.project.save_json(data, self.project.storyline_path(project_folder))
+
+    def get_turns(self, data: Dict[str, Any]) -> List[Dict[str, Any]]:
+        turns = []
+        for turn in data.get("turns", []):
+            if isinstance(turn, dict):
+                content = str(turn.get("content", "") or "")
+                origin = str(turn.get("origin", turn.get("author", "user")) or "user")
+            else:
+                content = str(turn)
+                origin = "user"
+            turns.append({"content": content, "origin": origin})
+        return turns
+
+    def update_turns(self, state: Dict[str, Any], turns: List[Dict[str, Any]]) -> Dict[str, Any]:
+        data = dict(state or {})
+        normalized: List[Dict[str, Any]] = []
+        for turn in turns:
+            content = str(turn.get("content", "") or "")
+            origin = str(turn.get("origin", "user") or "user")
+            normalized.append({"content": content, "origin": origin})
+        data["turns"] = normalized
+        return data
+
+    # --- Prompt helpers ---
+    def instruction_for_turn(self, index: int) -> str:
+        config = self.prompt_config or {}
+        instructions = config.get("turn_instructions")
+        if isinstance(instructions, list) and index < len(instructions):
+            candidate = instructions[index]
+            if isinstance(candidate, str) and candidate.strip():
+                return candidate.strip()
+        default = config.get("default_instruction")
+        if isinstance(default, str) and default.strip():
+            return default.strip()
+        return self.DEFAULT_INSTRUCTION
+
+    def build_prompt_context(
+        self,
+        project_folder: str,
+        turns: List[Dict[str, Any]],
+    ) -> Dict[str, str]:
+        context: Dict[str, str] = {}
+
+        # World & story summary
+        try:
+            story_data = self.project.read_json(self.project.story_path(project_folder))
+        except FileNotFoundError:
+            story_data = None
+        except Exception:
+            story_data = None
+        if story_data:
+            summary = summarize_value_for_prompt(story_data)
+            if summary:
+                context["World & Story"] = summary
+
+        # Character summary
+        character_summaries: List[str] = []
+        for name in sorted(self.project.list_characters(project_folder)):
+            try:
+                char_data = self.project.read_json(
+                    self.project.character_path(project_folder, name)
+                )
+            except FileNotFoundError:
+                continue
+            except Exception:
+                continue
+            summary = summarize_value_for_prompt(char_data)
+            label = format_field_label(name)
+            if summary:
+                character_summaries.append(f"{label}: {summary}")
+            else:
+                character_summaries.append(label)
+        if character_summaries:
+            context["Key Characters"] = "; ".join(character_summaries)
+
+        # Existing turns
+        if turns:
+            turn_summaries: List[str] = []
+            for idx, turn in enumerate(turns):
+                summary = summarize_value_for_prompt(turn.get("content", ""))
+                if summary:
+                    turn_summaries.append(f"{idx + 1}. {summary}")
+            if turn_summaries:
+                context["Existing Storyline Turns"] = " | ".join(turn_summaries)
+
+        return context
+
+    def turn_label(self, turn: Dict[str, Any], index: int) -> str:
+        summary = summarize_value_for_prompt(turn.get("content", ""))
+        summary = " ".join(summary.split()) if summary else "<empty>"
+        if len(summary) > 80:
+            summary = summary[:77] + "..."
+        return f"{index + 1}. {summary}"

--- a/tests/sample_data/example_project/Storyline.json
+++ b/tests/sample_data/example_project/Storyline.json
@@ -1,0 +1,14 @@
+{
+  "title": "Mysteries of the Ember Vale",
+  "summary": "A conspiracy threatens the balance between the arcane conclave and the common folk.",
+  "turns": [
+    {
+      "content": "The heroes arrive in Ember Vale and witness a ritual gone awry, hinting at forbidden magic.",
+      "origin": "user"
+    },
+    {
+      "content": "An envoy of the conclave reveals that a renegade mage seeks to harness a sleeping titan beneath the valley.",
+      "origin": "user"
+    }
+  ]
+}

--- a/tests/test_storyline_manager.py
+++ b/tests/test_storyline_manager.py
@@ -1,0 +1,79 @@
+import os
+import shutil
+
+def _make_paths(tmp_path):
+    from story_builder.project import ProjectPaths
+
+    paths = ProjectPaths()
+    base = tmp_path / "storyline"
+    base.mkdir()
+    paths.base_dir = str(base)
+    paths.templates_dir = str(base / "json_templates")
+    paths.projects_root = str(base / "json_projects")
+    os.makedirs(paths.templates_dir, exist_ok=True)
+    os.makedirs(paths.projects_root, exist_ok=True)
+
+    repo_templates = os.path.join(os.path.dirname(os.path.dirname(__file__)), "json_templates")
+    for name in ["storyline_template.json", "storyline_template_prompt.json"]:
+        shutil.copy(os.path.join(repo_templates, name), paths.templates_dir)
+
+    return paths
+
+
+def test_storyline_manager_initializes_and_persists(tmp_path):
+    from story_builder.project import Project
+    from story_builder.storyline import StorylineManager
+
+    paths = _make_paths(tmp_path)
+    project = Project(paths)
+    manager = StorylineManager(project)
+
+    project_folder = os.path.join(paths.projects_root, "demo")
+    os.makedirs(project_folder, exist_ok=True)
+
+    data = manager.load(project_folder)
+    assert data["turns"] == []
+
+    turns = [{"content": "Opening scene", "origin": "user"}]
+    state = manager.update_turns(data, turns)
+    manager.save(project_folder, state)
+
+    reloaded = manager.load(project_folder)
+    assert reloaded["turns"][0]["content"] == "Opening scene"
+
+
+def test_storyline_prompt_helpers(tmp_path):
+    from story_builder.project import Project
+    from story_builder.storyline import StorylineManager
+
+    paths = _make_paths(tmp_path)
+    project = Project(paths)
+    manager = StorylineManager(project)
+    manager.load_prompt_config()
+
+    first_instruction = manager.instruction_for_turn(0)
+    fallback_instruction = manager.instruction_for_turn(10)
+
+    assert "hook" in first_instruction.lower()
+    assert "storyline" in fallback_instruction.lower()
+
+    project_folder = os.path.join(paths.projects_root, "demo")
+    os.makedirs(project.characters_dir(project_folder), exist_ok=True)
+    manager.ensure_initialized(project_folder)
+
+    project.save_json(
+        {"story_preferences": {"setting": "Sky city"}},
+        project.story_path(project_folder),
+    )
+    project.save_json(
+        {"name": "Aria", "role": "wizard"},
+        project.character_path(project_folder, "aria"),
+    )
+
+    turns = [{"content": "The heroes arrive in the floating market."}]
+    context = manager.build_prompt_context(project_folder, turns)
+
+    combined = "\n".join(context.values())
+    assert "sky city" in combined.lower()
+    assert "aria" in combined.lower()
+    assert "1." in combined


### PR DESCRIPTION
## Summary
- add a Write Storyline tab that lets users add, edit, reorder, and delete sequential turns with manual or GPT-assisted entry
- introduce a StorylineManager to manage storyline storage, prompting context, and configurable instructions via new templates
- seed storyline sample data and add tests covering initialization, persistence, and prompt context generation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da52c3a9dc8324a80b309ede9e0e36