### PR TITLE
Implement turn processing lifecycle with per-player story updates

### DIFF
--- a/story_builder/storyline.py
+++ b/story_builder/storyline.py
@@ -62,24 +62,30 @@ class StorylineManager:
         self.project.save_json(data, self.project.storyline_path(project_folder))
 
     def get_turns(self, data: Dict[str, Any]) -> List[Dict[str, Any]]:
-        turns = []
+        turns: List[Dict[str, Any]] = []
         for turn in data.get("turns", []):
             if isinstance(turn, dict):
-                content = str(turn.get("content", "") or "")
-                origin = str(turn.get("origin", turn.get("author", "user")) or "user")
+                normalized = dict(turn)
+                normalized["content"] = str(normalized.get("content", "") or "")
+                normalized["origin"] = str(
+                    normalized.get("origin", normalized.get("author", "user")) or "user"
+                )
             else:
-                content = str(turn)
-                origin = "user"
-            turns.append({"content": content, "origin": origin})
+                normalized = {"content": str(turn), "origin": "user"}
+            turns.append(normalized)
         return turns
 
     def update_turns(self, state: Dict[str, Any], turns: List[Dict[str, Any]]) -> Dict[str, Any]:
         data = dict(state or {})
         normalized: List[Dict[str, Any]] = []
         for turn in turns:
-            content = str(turn.get("content", "") or "")
-            origin = str(turn.get("origin", "user") or "user")
-            normalized.append({"content": content, "origin": origin})
+            if isinstance(turn, dict):
+                normalized_turn = dict(turn)
+            else:
+                normalized_turn = {"content": turn}
+            normalized_turn["content"] = str(normalized_turn.get("content", "") or "")
+            normalized_turn["origin"] = str(normalized_turn.get("origin", "user") or "user")
+            normalized.append(normalized_turn)
         data["turns"] = normalized
         return data
 

--- a/story_builder/turn_processor.py
+++ b/story_builder/turn_processor.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, MutableMapping
+
+from .logger import Logger
+from .project import Project
+from .storyline import StorylineManager
+
+
+def _clean_text(value: object) -> str:
+    if value is None:
+        return ""
+    text = str(value)
+    return text.strip()
+
+
+def _clean_sequence(value: object) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        candidates = [value]
+    elif isinstance(value, Iterable):  # type: ignore[unreachable]
+        candidates = list(value)
+    else:
+        return []
+    cleaned: List[str] = []
+    for candidate in candidates:
+        text = _clean_text(candidate)
+        if text:
+            cleaned.append(text)
+    return cleaned
+
+
+@dataclass
+class PlayerTurnRecord:
+    """Structured snapshot for a single player's experience of a turn."""
+
+    turn: int
+    action: str
+    outcome: str
+    global_summary: str
+    reflection: str = ""
+    candidate_actions: List[str] | None = None
+
+    def to_dict(self) -> Dict[str, object]:
+        data: Dict[str, object] = {
+            "turn": self.turn,
+            "action": self.action,
+            "outcome": self.outcome,
+            "global_summary": self.global_summary,
+            "reflection": self.reflection,
+        }
+        if self.candidate_actions:
+            data["candidate_actions"] = list(self.candidate_actions)
+        else:
+            data["candidate_actions"] = []
+        return data
+
+
+class TurnProcessor:
+    """Persist the full lifecycle for a multiplayer storytelling turn."""
+
+    def __init__(
+        self,
+        project: Project,
+        storyline_manager: StorylineManager | None = None,
+        logger: Logger | None = None,
+    ) -> None:
+        self.project = project
+        self.storyline_manager = storyline_manager or StorylineManager(project)
+        self.logger = logger
+
+    # --- Public API -------------------------------------------------
+    def process_turn(
+        self,
+        project_folder: str,
+        player_actions: Mapping[str, str] | None,
+        gm_summary: str,
+        per_player_outcomes: Mapping[str, str] | None,
+        player_reflections: Mapping[str, object] | None = None,
+    ) -> Dict[str, object]:
+        """Record the outcome of a turn across global and per-player storylines."""
+
+        normalized_actions = self._normalize_mapping(player_actions)
+        normalized_outcomes = self._normalize_mapping(per_player_outcomes)
+        reflections = player_reflections or {}
+
+        storyline_state = self.storyline_manager.load(project_folder)
+        turns = self.storyline_manager.get_turns(storyline_state)
+        turn_number = len(turns) + 1
+
+        turn_entry: Dict[str, object] = {
+            "turn": turn_number,
+            "content": _clean_text(gm_summary),
+            "origin": "gm",
+            "player_actions": normalized_actions,
+            "per_player_outcomes": normalized_outcomes,
+        }
+
+        turns.append(turn_entry)
+        storyline_state = self.storyline_manager.update_turns(storyline_state, turns)
+        self.storyline_manager.save(project_folder, storyline_state)
+
+        impacted_players = set(normalized_actions) | set(normalized_outcomes) | set(reflections)
+        for player in sorted(impacted_players):
+            self._append_player_turn(
+                project_folder,
+                player,
+                turn_number,
+                gm_summary,
+                normalized_actions.get(player, ""),
+                normalized_outcomes.get(player, ""),
+                reflections.get(player),
+            )
+
+        result: Dict[str, object] = {
+            "turn": turn_number,
+            "storyline_entry": turn_entry,
+            "players": {
+                player: self._load_player_state(project_folder, player)
+                for player in impacted_players
+            },
+        }
+
+        if self.logger:
+            self.logger.log(
+                "TurnProcessor: processed turn %s for players %s",
+                turn_number,
+                ", ".join(sorted(impacted_players)),
+            )
+
+        return result
+
+    # --- Internal helpers ------------------------------------------
+    def _normalize_mapping(
+        self, values: Mapping[str, str] | None
+    ) -> Dict[str, str]:
+        normalized: Dict[str, str] = {}
+        if not values:
+            return normalized
+        for key, value in values.items():
+            cleaned_key = _clean_text(key)
+            if not cleaned_key:
+                continue
+            normalized[cleaned_key] = _clean_text(value)
+        return normalized
+
+    def _append_player_turn(
+        self,
+        project_folder: str,
+        player: str,
+        turn_number: int,
+        gm_summary: str,
+        action: str,
+        outcome: str,
+        reflection_payload: object,
+    ) -> None:
+        path = self.project.character_path(project_folder, player)
+        state = self._load_player_state(project_folder, player)
+
+        reflection_text, candidate_actions = self._normalize_reflection(reflection_payload)
+
+        record = PlayerTurnRecord(
+            turn=turn_number,
+            action=action,
+            outcome=outcome,
+            global_summary=_clean_text(gm_summary),
+            reflection=reflection_text,
+            candidate_actions=candidate_actions or None,
+        )
+
+        state_turns = state.setdefault("turns", [])
+        if not isinstance(state_turns, list):
+            state_turns = []
+        state_turns.append(record.to_dict())
+        state["turns"] = state_turns
+
+        state.setdefault("name", player)
+        state["last_turn"] = turn_number
+
+        self.project.save_json(state, path)
+
+    def _load_player_state(self, project_folder: str, player: str) -> Dict[str, object]:
+        path = self.project.character_path(project_folder, player)
+        try:
+            data = self.project.read_json(path)
+        except FileNotFoundError:
+            data = {}
+        except Exception:
+            data = {}
+
+        if not isinstance(data, MutableMapping):
+            data = {}
+        data = dict(data)
+        data.setdefault("name", player)
+        turns = data.get("turns")
+        if not isinstance(turns, list):
+            turns = []
+        data["turns"] = turns
+        if "last_turn" in data and not isinstance(data["last_turn"], int):
+            try:
+                data["last_turn"] = int(data["last_turn"])
+            except Exception:
+                data["last_turn"] = len(turns)
+        else:
+            data.setdefault("last_turn", len(turns))
+        return data
+
+    def _normalize_reflection(self, payload: object) -> tuple[str, List[str]]:
+        if payload is None:
+            return "", []
+
+        if isinstance(payload, Mapping):
+            notes_sources: List[str] = []
+            for key in ("notes", "thoughts", "reflection"):
+                if key in payload:
+                    text = _clean_text(payload.get(key))
+                    if text:
+                        notes_sources.append(text)
+            notes = "\n\n".join(notes_sources)
+            candidates: List[str] = []
+            for key in ("candidate_actions", "plans", "next_actions", "next_steps"):
+                if key in payload:
+                    candidates.extend(_clean_sequence(payload.get(key)))
+            return notes, candidates
+
+        if isinstance(payload, Iterable) and not isinstance(payload, (str, bytes)):
+            return "", _clean_sequence(payload)
+
+        return _clean_text(payload), []

--- a/tests/test_turn_processor.py
+++ b/tests/test_turn_processor.py
@@ -1,0 +1,88 @@
+import os
+import shutil
+
+
+def _make_paths(tmp_path):
+    from story_builder.project import ProjectPaths
+
+    paths = ProjectPaths()
+    base = tmp_path / "turns"
+    base.mkdir()
+    paths.base_dir = str(base)
+    paths.templates_dir = str(base / "json_templates")
+    paths.projects_root = str(base / "json_projects")
+    os.makedirs(paths.templates_dir, exist_ok=True)
+    os.makedirs(paths.projects_root, exist_ok=True)
+
+    repo_templates = os.path.join(os.path.dirname(os.path.dirname(__file__)), "json_templates")
+    shutil.copy(os.path.join(repo_templates, "storyline_template.json"), paths.templates_dir)
+    shutil.copy(os.path.join(repo_templates, "storyline_template_prompt.json"), paths.templates_dir)
+
+    return paths
+
+
+def test_turn_processor_writes_storyline_and_players(tmp_path):
+    from story_builder.project import Project
+    from story_builder.storyline import StorylineManager
+    from story_builder.turn_processor import TurnProcessor
+
+    paths = _make_paths(tmp_path)
+    project = Project(paths)
+    storyline = StorylineManager(project)
+    processor = TurnProcessor(project, storyline)
+
+    project_folder = os.path.join(paths.projects_root, "campaign")
+    os.makedirs(project_folder, exist_ok=True)
+
+    turn_result = processor.process_turn(
+        project_folder,
+        player_actions={"Aria": "Study the relic", "Bram": "Guard the door"},
+        gm_summary="The relic hums as Aria studies it while Bram keeps watch.",
+        per_player_outcomes={
+            "Aria": "She deciphers a hidden rune and gains new insight.",
+            "Bram": "He spots approaching footsteps in time to warn the team.",
+        },
+        player_reflections={
+            "Aria": {
+                "notes": "Need to cross-reference rune patterns.",
+                "candidate_actions": ["Consult the archivist"],
+            },
+            "Bram": "Stay alert for the next watch.",
+        },
+    )
+
+    assert turn_result["turn"] == 1
+
+    storyline_path = project.storyline_path(project_folder)
+    data = project.read_json(storyline_path)
+    assert data["turns"][0]["content"].startswith("The relic hums")
+    assert data["turns"][0]["player_actions"]["Aria"] == "Study the relic"
+    assert data["turns"][0]["per_player_outcomes"]["Bram"].startswith("He spots")
+
+    aria_file = project.character_path(project_folder, "Aria")
+    aria = project.read_json(aria_file)
+    assert aria["turns"][0]["global_summary"].startswith("The relic hums")
+    assert aria["turns"][0]["action"] == "Study the relic"
+    assert aria["turns"][0]["candidate_actions"] == ["Consult the archivist"]
+
+    bram_file = project.character_path(project_folder, "Bram")
+    bram = project.read_json(bram_file)
+    assert bram["turns"][0]["reflection"] == "Stay alert for the next watch."
+    assert bram["turns"][0]["candidate_actions"] == []
+
+    processor.process_turn(
+        project_folder,
+        player_actions={"Aria": "Lead the team toward the footsteps"},
+        gm_summary="The party advances carefully into the corridor.",
+        per_player_outcomes={"Bram": "He points out a tripwire before anyone triggers it."},
+        player_reflections={"Aria": {"thoughts": "Need backup soon.", "plans": "Find allies"}},
+    )
+
+    aria = project.read_json(aria_file)
+    assert len(aria["turns"]) == 2
+    assert aria["turns"][1]["turn"] == 2
+    assert aria["turns"][1]["candidate_actions"] == ["Find allies"]
+
+    bram = project.read_json(bram_file)
+    assert len(bram["turns"]) == 2  # Second turn still records outcome even without action
+    assert bram["turns"][1]["outcome"].startswith("He points out a tripwire")


### PR DESCRIPTION
## Summary
- preserve extended metadata in storyline turns so additional lifecycle details are retained
- add a TurnProcessor that records GM summaries, player outcomes, and reflections across shared and per-player files
- cover the new lifecycle with unit tests verifying storyline and character persistence

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da8f1818a48324b388299e032ae55b