### PR TITLE
Allow Logger.log to format messages with arguments

### DIFF
--- a/story_builder/logger.py
+++ b/story_builder/logger.py
@@ -14,13 +14,25 @@ class Logger:
         except Exception:
             return False
 
-    def log(self, msg: str) -> None:
+    def log(self, msg: str, *args, **kwargs) -> None:
         if not self.enabled():
             return
-        print(msg)
+        if args:
+            try:
+                formatted = msg % args
+            except Exception:
+                formatted = str(msg)
+        elif kwargs:
+            try:
+                formatted = msg % kwargs
+            except Exception:
+                formatted = str(msg)
+        else:
+            formatted = str(msg)
+        print(formatted)
         if self.log_file:
             try:
                 with open(self.log_file, "a", encoding="utf-8") as f:
-                    f.write(str(msg) + "\n")
+                    f.write(formatted + "\n")
             except Exception:
                 pass


### PR DESCRIPTION
## Summary
- update `Logger.log` to accept optional formatting arguments and build the final message before emitting it
- ensure the formatted message is printed and persisted to the log file

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dad2e6e4f083248cc03ac91a2822c7