### PR TITLE
Refine storyline turn prompting sequence

### DIFF
--- a/story_builder/turn_processor.py
+++ b/story_builder/turn_processor.py
@@ -75,8 +75,8 @@ class TurnProcessor:
     def process_turn(
         self,
         project_folder: str,
-        player_actions: Mapping[str, str] | None,
         gm_summary: str,
+        player_actions: Mapping[str, str] | None,
         per_player_outcomes: Mapping[str, str] | None,
         player_reflections: Mapping[str, object] | None = None,
     ) -> Dict[str, object]:

--- a/tests/test_turn_processor.py
+++ b/tests/test_turn_processor.py
@@ -36,13 +36,13 @@ def test_turn_processor_writes_storyline_and_players(tmp_path):
 
     turn_result = processor.process_turn(
         project_folder,
-        player_actions={"Aria": "Study the relic", "Bram": "Guard the door"},
-        gm_summary="The relic hums as Aria studies it while Bram keeps watch.",
-        per_player_outcomes={
+        "The relic hums as Aria studies it while Bram keeps watch.",
+        {"Aria": "Study the relic", "Bram": "Guard the door"},
+        {
             "Aria": "She deciphers a hidden rune and gains new insight.",
             "Bram": "He spots approaching footsteps in time to warn the team.",
         },
-        player_reflections={
+        {
             "Aria": {
                 "notes": "Need to cross-reference rune patterns.",
                 "candidate_actions": ["Consult the archivist"],
@@ -72,10 +72,10 @@ def test_turn_processor_writes_storyline_and_players(tmp_path):
 
     processor.process_turn(
         project_folder,
-        player_actions={"Aria": "Lead the team toward the footsteps"},
-        gm_summary="The party advances carefully into the corridor.",
-        per_player_outcomes={"Bram": "He points out a tripwire before anyone triggers it."},
-        player_reflections={"Aria": {"thoughts": "Need backup soon.", "plans": "Find allies"}},
+        "The party advances carefully into the corridor.",
+        {"Aria": "Lead the team toward the footsteps"},
+        {"Bram": "He points out a tripwire before anyone triggers it."},
+        {"Aria": {"thoughts": "Need backup soon.", "plans": "Find allies"}},
     )
 
     aria = project.read_json(aria_file)


### PR DESCRIPTION
## Summary
- gather player actions before the GM summary and reuse the captured data when prompting for outcomes and reflections
- update TurnProcessor.process_turn to accept the GM summary before player data and adjust the storyline turn flow accordingly
- refresh turn processor tests to cover the new argument ordering

## Testing
- pytest tests/test_turn_processor.py

------
https://chatgpt.com/codex/tasks/task_e_68dad71be7e083248788e737e26cdcb7