### PR TITLE
Add prompt metadata with per-field token limits

### DIFF
--- a/json_templates/character_template_prompt.json
+++ b/json_templates/character_template_prompt.json
@@ -1,8 +1,26 @@
 {
-  "name": "Suggest a unique character name",
-  "race": "Suggest a fantasy race (Human, Elf, Dwarf, etc.)",
-  "class": "Suggest a character class (Warrior, Mage, Rogue, etc.)",
-  "background": "Suggest a short backstory",
-  "motivation": "Suggest what drives this character",
-  "personality_traits": "Suggest 2-3 personality traits"
+  "name": {
+    "instruction": "Suggest a unique character name",
+    "max_tokens": 32
+  },
+  "race": {
+    "instruction": "Suggest a fantasy race (Human, Elf, Dwarf, etc.)",
+    "max_tokens": 48
+  },
+  "class": {
+    "instruction": "Suggest a character class (Warrior, Mage, Rogue, etc.)",
+    "max_tokens": 48
+  },
+  "background": {
+    "instruction": "Suggest a short backstory",
+    "max_tokens": 120
+  },
+  "motivation": {
+    "instruction": "Suggest what drives this character",
+    "max_tokens": 72
+  },
+  "personality_traits": {
+    "instruction": "Suggest 2-3 personality traits",
+    "max_tokens": 72
+  }
 }

--- a/json_templates/story_template_prompt.json
+++ b/json_templates/story_template_prompt.json
@@ -1,23 +1,68 @@
 {
   "story_preferences": {
-    "setting": "Suggest a creative setting (e.g., medieval fantasy, sci-fi, modern supernatural, or something original).",
-    "themes": "Suggest 2-3 compelling themes for an adventure (e.g., heroic adventure, dark mystery, political intrigue).",
-    "tone": "Suggest a fitting tone (serious, lighthearted, grimdark, whimsical) for the story.",
-    "scope": "Suggest whether this should be a short one-shot, episodic campaign, or long epic saga.",
-    "player_goals": "Suggest 2-3 fun player goals (e.g., solve mysteries, become powerful, build alliances)."
+    "setting": {
+      "instruction": "Suggest a creative setting (e.g., medieval fantasy, sci-fi, modern supernatural, or something original).",
+      "max_tokens": 80
+    },
+    "themes": {
+      "instruction": "Suggest 2-3 compelling themes for an adventure (e.g., heroic adventure, dark mystery, political intrigue).",
+      "max_tokens": 80
+    },
+    "tone": {
+      "instruction": "Suggest a fitting tone (serious, lighthearted, grimdark, whimsical) for the story.",
+      "max_tokens": 48
+    },
+    "scope": {
+      "instruction": "Suggest whether this should be a short one-shot, episodic campaign, or long epic saga.",
+      "max_tokens": 48
+    },
+    "player_goals": {
+      "instruction": "Suggest 2-3 fun player goals (e.g., solve mysteries, become powerful, build alliances).",
+      "max_tokens": 80
+    }
   },
   "world_details": {
-    "magic_level": "Suggest a magic level (low, medium, high) that fits the story.",
-    "technology_level": "Suggest a technology level (ancient, medieval, steampunk, futuristic) that fits the story.",
-    "factions": "Suggest 2-3 interesting factions (e.g., kingdoms, guilds, councils) that could exist in the world.",
-    "special_requests": "Suggest any unique twists, restrictions, or requests that could make the world interesting."
+    "magic_level": {
+      "instruction": "Suggest a magic level (low, medium, high) that fits the story.",
+      "max_tokens": 48
+    },
+    "technology_level": {
+      "instruction": "Suggest a technology level (ancient, medieval, steampunk, futuristic) that fits the story.",
+      "max_tokens": 48
+    },
+    "factions": {
+      "instruction": "Suggest 2-3 interesting factions (e.g., kingdoms, guilds, councils) that could exist in the world.",
+      "max_tokens": 96
+    },
+    "special_requests": {
+      "instruction": "Suggest any unique twists, restrictions, or requests that could make the world interesting.",
+      "max_tokens": 96
+    }
   },
   "character": {
-    "name": "Suggest a fantasy character name.",
-    "race": "Suggest a race for the character (e.g., human, elf, dwarf, or something unique).",
-    "class": "Suggest a fitting class for the character (e.g., fighter, wizard, rogue).",
-    "background": "Suggest a short backstory for the character.",
-    "motivation": "Suggest a strong motivation for the character.",
-    "personality_traits": "Suggest 2-3 personality traits for the character."
+    "name": {
+      "instruction": "Suggest a fantasy character name.",
+      "max_tokens": 32
+    },
+    "race": {
+      "instruction": "Suggest a race for the character (e.g., human, elf, dwarf, or something unique).",
+      "max_tokens": 48
+    },
+    "class": {
+      "instruction": "Suggest a fitting class for the character (e.g., fighter, wizard, rogue).",
+      "max_tokens": 48
+    },
+    "background": {
+      "instruction": "Suggest a short backstory for the character.",
+      "max_tokens": 120
+    },
+    "motivation": {
+      "instruction": "Suggest a strong motivation for the character.",
+      "max_tokens": 72
+    },
+    "personality_traits": {
+      "instruction": "Suggest 2-3 personality traits for the character.",
+      "max_tokens": 72
+    }
   }
 }

--- a/json_templates/storyline_template_prompt.json
+++ b/json_templates/storyline_template_prompt.json
@@ -1,10 +1,28 @@
 {
-  "default_instruction": "Write the next major beat of the storyline in 2-4 sentences. Focus on strong player hooks, escalating stakes, and vivid sensory details.",
+  "default_instruction": {
+    "instruction": "Write the next major beat of the storyline in 2-4 sentences. Focus on strong player hooks, escalating stakes, and vivid sensory details.",
+    "max_tokens": 200
+  },
   "turn_instructions": [
-    "Establish the campaign hook, location, and initial conflict that draws the heroes together.",
-    "Introduce the primary antagonist or obstacle that complicates the heroes' goals.",
-    "Describe a turning point that raises the stakes and reveals hidden information.",
-    "Outline the climactic showdown or challenge and the consequences of success or failure.",
-    "Suggest an epilogue beat that teases future adventures or unresolved threads."
+    {
+      "instruction": "Establish the campaign hook, location, and initial conflict that draws the heroes together.",
+      "max_tokens": 180
+    },
+    {
+      "instruction": "Introduce the primary antagonist or obstacle that complicates the heroes' goals.",
+      "max_tokens": 180
+    },
+    {
+      "instruction": "Describe a turning point that raises the stakes and reveals hidden information.",
+      "max_tokens": 180
+    },
+    {
+      "instruction": "Outline the climactic showdown or challenge and the consequences of success or failure.",
+      "max_tokens": 200
+    },
+    {
+      "instruction": "Suggest an epilogue beat that teases future adventures or unresolved threads.",
+      "max_tokens": 180
+    }
   ]
 }

--- a/story_builder/autofill.py
+++ b/story_builder/autofill.py
@@ -23,12 +23,12 @@ class AutofillService:
             return False
 
 
-    def generate(self, prompt_text: str) -> str:
+    def generate(self, prompt_text: str, *, max_tokens: Optional[int] = None) -> str:
         if self._stub_mode():
             return "".join(random.choices(string.ascii_uppercase + string.digits, k=4))
         if tg is None:
             # Fallback if text_generator isn't available
             return "".join(random.choices(string.ascii_lowercase, k=12))
         gen = tg.TextGenerator(max_new_tokens=self.max_new_tokens)
-        out = gen.generate_response(prompt_text)
+        out = gen.generate_response(prompt_text, max_new_tokens=max_tokens)
         return (out or "").strip()

--- a/story_builder/storyline.py
+++ b/story_builder/storyline.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List
 
 from .project import Project
 from .logger import Logger
-from .utils import summarize_value_for_prompt, format_field_label
+from .utils import summarize_value_for_prompt, format_field_label, PromptSpec
 
 
 class StorylineManager:
@@ -90,17 +90,20 @@ class StorylineManager:
         return data
 
     # --- Prompt helpers ---
-    def instruction_for_turn(self, index: int) -> str:
+    def instruction_for_turn(self, index: int) -> PromptSpec:
         config = self.prompt_config or {}
+
         instructions = config.get("turn_instructions")
         if isinstance(instructions, list) and index < len(instructions):
-            candidate = instructions[index]
-            if isinstance(candidate, str) and candidate.strip():
-                return candidate.strip()
-        default = config.get("default_instruction")
-        if isinstance(default, str) and default.strip():
-            return default.strip()
-        return self.DEFAULT_INSTRUCTION
+            candidate = PromptSpec.from_config(instructions[index])
+            if candidate.instruction:
+                return candidate
+
+        default_spec = PromptSpec.from_config(config.get("default_instruction"))
+        if default_spec.instruction:
+            return default_spec
+
+        return PromptSpec(self.DEFAULT_INSTRUCTION)
 
     def build_prompt_context(
         self,

--- a/tests/test_fieldwalker.py
+++ b/tests/test_fieldwalker.py
@@ -7,13 +7,22 @@ class DummyDialog:
         self.exit_early = False
         self.captured = []
 
-    def ask_field(self, title, key, suggestion, prompt_instruction=None, context=None):
+    def ask_field(
+        self,
+        title,
+        key,
+        suggestion,
+        prompt_instruction=None,
+        context=None,
+        prompt_spec=None,
+    ):
         self.captured.append({
             "title": title,
             "key": key,
             "suggestion": suggestion,
             "prompt_instruction": prompt_instruction,
             "context": context,
+            "prompt_spec": prompt_spec,
         })
         try:
             return next(self.responses)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -82,7 +82,7 @@ def test_edit_world_manual_and_autofill():
     # First field returns "test", second field comes from stub autofill
     responses = iter(["test"])
     app.dialog_runner.ask_field = lambda *a, **k: next(responses, app.autofill.generate("tone"))
-    app.autofill.generate = lambda prompt: "ABCD"
+    app.autofill.generate = lambda prompt, **kwargs: "ABCD"
 
     app._edit_world(folder)
 
@@ -127,7 +127,7 @@ def test_edit_character_manual_and_autofill():
     # First response = "heroic", then stub autofill
     responses = iter(["heroic"])
     app.dialog_runner.ask_field = lambda *a, **k: next(responses, app.autofill.generate("role"))
-    app.autofill.generate = lambda prompt: "WXYZ"
+    app.autofill.generate = lambda prompt, **kwargs: "WXYZ"
 
     app._edit_character(folder, preselected="test_character")
 
@@ -189,7 +189,7 @@ def test_autofill_storyline_turn():
         "Villain outcome",
         "Villain reflection",
     ])
-    app.autofill.generate = lambda prompt: next(responses)
+    app.autofill.generate = lambda prompt, **kwargs: next(responses)
 
     app._autofill_storyline_turn(folder)
 

--- a/tests/test_prompt_logic.py
+++ b/tests/test_prompt_logic.py
@@ -20,7 +20,15 @@ class CaptureDialog:
         self.exit_early = False
         self.calls = []
 
-    def ask_field(self, title, key, suggestion, prompt_instruction=None, context=None):
+    def ask_field(
+        self,
+        title,
+        key,
+        suggestion,
+        prompt_instruction=None,
+        context=None,
+        prompt_spec=None,
+    ):
         self.calls.append(
             {
                 "title": title,
@@ -28,6 +36,7 @@ class CaptureDialog:
                 "suggestion": suggestion,
                 "prompt_instruction": prompt_instruction,
                 "context": context,
+                "prompt_spec": prompt_spec,
             }
         )
         try:

--- a/tests/test_storyline_manager.py
+++ b/tests/test_storyline_manager.py
@@ -54,8 +54,8 @@ def test_storyline_prompt_helpers(tmp_path):
     first_instruction = manager.instruction_for_turn(0)
     fallback_instruction = manager.instruction_for_turn(10)
 
-    assert "hook" in first_instruction.lower()
-    assert "storyline" in fallback_instruction.lower()
+    assert "hook" in first_instruction.instruction.lower()
+    assert "storyline" in fallback_instruction.instruction.lower()
 
     project_folder = os.path.join(paths.projects_root, "demo")
     os.makedirs(project.characters_dir(project_folder), exist_ok=True)


### PR DESCRIPTION
## Summary
- restructure prompt templates so each prompt includes both instruction text and a max token budget
- add a PromptSpec helper and thread prompt metadata through dialogs, autofill, and storyline flows so max token limits reach the generator
- update tests for the new prompt structure and ensure storyline prompts still return usable instructions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de5d3aa9d883249ec939f9b91a1031